### PR TITLE
Add site via contextmenu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/*
 /build
 .settings
 node_modules/
+todo.md

--- a/src/background.js
+++ b/src/background.js
@@ -47,6 +47,47 @@ function saveOptions(o) {
   }
 }
 
+// This does not require "permissions":["tabs"] becuase it only acts on its
+// current tab.
+chrome.contextMenus.create({
+  title:"Add site to SA blacklist",
+  contexts:["all"],
+  type:"normal",
+  onclick:function(info, tab) {
+    console.log("tab.url:", tab.url)
+
+    // 'document.location.hostname' here is a string containing our app ID.
+    // So we'll need to parse tab.url (or info.pageUrl) instead.
+    var dummy = document.createElement('a')
+    dummy.href = tab.url
+    console.log("dummy.hostname=",dummy.hostname)
+
+    // Use dummy.hostname for now; If @davidparsson agrees on issue #68, then
+    // this should change to use dummy.host as well.
+    blacklist = localStorage["blacklist"].split('\n')
+    console.log("blacklist=",blacklist)
+
+    for (var i = blacklist.length - 1; i >= 0; i--) {
+      var blacklistEntry = blacklist[i].trim();
+      console.log('testing entry', blacklistEntry)
+      if (dummy.hostname === blacklistEntry) {
+        // no need to check subdomains when adding to list
+        console.log('hostname already in blacklist')
+        return
+      }
+    }
+    // else
+    console.log('pushing to blacklist')
+    console.log('before', localStorage['blacklist'])
+
+    blacklist.push(dummy.hostname)
+    localStorage['blacklist'] = blacklist.join('\n')
+
+    console.log('after', localStorage['blacklist'])
+    saveOptions({o:'blacklist'})
+  }
+})
+
 // Inject content script into all existing tabs (doesn't work)
 // This functionality requires
 //  "permissions": ["tabs"]

--- a/src/background.js
+++ b/src/background.js
@@ -54,36 +54,28 @@ chrome.contextMenus.create({
   contexts:["all"],
   type:"normal",
   onclick:function(info, tab) {
-    console.log("tab.url:", tab.url)
-
     // 'document.location.hostname' here is a string containing our app ID.
-    // So we'll need to parse tab.url (or info.pageUrl) instead.
+    // info.pageUrl and tab.url are both the full URL of this page, we only
+    // want the hostname, so use a dummy object (instead of requiring another
+    // library to parse the URL)
     var dummy = document.createElement('a')
     dummy.href = tab.url
-    console.log("dummy.hostname=",dummy.hostname)
 
     // Use dummy.hostname for now; If @davidparsson agrees on issue #68, then
     // this should change to use dummy.host as well.
     blacklist = localStorage["blacklist"].split('\n')
-    console.log("blacklist=",blacklist)
 
     for (var i = blacklist.length - 1; i >= 0; i--) {
       var blacklistEntry = blacklist[i].trim();
-      console.log('testing entry', blacklistEntry)
       if (dummy.hostname === blacklistEntry) {
         // no need to check subdomains when adding to list
-        console.log('hostname already in blacklist')
+        console.log(dummy.hostname,'already in blacklist')
         return
       }
     }
-    // else
-    console.log('pushing to blacklist')
-    console.log('before', localStorage['blacklist'])
-
+    console.log('pushing',dummy.hostname,'to blacklist')
     blacklist.push(dummy.hostname)
     localStorage['blacklist'] = blacklist.join('\n')
-
-    console.log('after', localStorage['blacklist'])
     saveOptions({o:'blacklist'})
   }
 })

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,6 +23,9 @@
   "background": {
     "scripts": ["background.js"]
   },
+  "permissions": [
+    "contextMenus"
+  ],
   "options_page": "options.html",
   "manifest_version": 2,
   "minimum_chrome_version": "49"


### PR DESCRIPTION
This PR adds a context-menu option to add the current site to the list of blacklisted domains.

This works fine as is, but there is a small bug. If the options page is open, the blacklist will be reset to it's previous contents (ie. it's not auto-updated, and reload doesn't "fix" it). Object.observe() and Object.prototype.watch() are both deprecated, so I'm not sure how to fix this. Any advice?