### PR TITLE
Update manifest to v3

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!-- Please write a short issue description below this line and supply details about your setup below. Thanks! -->
 
 My setup:
-- Mouse button used when scrolling: 
-- Chrome version: 
-- Operating system: 
+
+- Mouse button used when scrolling:
+- Chrome version:
+- Operating system:

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Scrollbar Anywhere
-==================
+# Scrollbar Anywhere
 
 ### **HELP WANTED:** This extension is becoming unusable due to Chrome's [deprecations for extensions](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3), and I don't have the time to fix this. See https://github.com/davidparsson/scrollbar-anywhere/pull/78 for progress.
 
@@ -9,55 +8,70 @@ If you want grab-and-drag style scrolling, just set it up in the options.
 
 The extension is based on the [Wet Banana extension](https://github.com/jedediah/wetbanana) and inspired by Scrollbar Anywhere for Firefox.
 
-Change Log
-----------
+## Change Log
 
 ### 2.17
+
 - Prevent the configured extra keys to interfere with scrolling.
 
 ### 2.16
+
 - Stop gliding when a key is pressed or the mouse wheel is scrolled.
 - Fix a bug where the default mouse click actions were incorrectly prevented.
 
 ### 2.15
+
 - Fix a bug where having an empty blacklist would disable the extension for `file:///` URLs.
 
 ### 2.14
+
 - Fix scrolling on some sites in Chrome v61+, by using `document.scrollingElement` as the outmost scrolling element, instead of `document.body`, even if `document.body` seems scrollable.
 
 ### 2.13
+
 - Fix scrolling in Chrome v61+, by using `document.scrollingElement` as the outmost scrolling element, instead of `document.body`.
 
 ### 2.12
+
 - Fix scrolling in Chrome v60+, by looking at the `buttons` property of the `mousemove` event.
 
 ### 2.11
+
 - Add a blacklist, allowing users to disable scrolling on certain domains.
 - Fixed a bug where settings in open multi-frame tabs were not updated.
 
 ### 2.10
+
 - Fixed a bug where settings in open tabs were not updated.
 
 ### 2.9
+
 - Fixed a bug where left-clicking would leave dragging enabled on some web pages.
 
 ### 2.8
+
 - Fixed a bug where left-clicking would leave dragging enabled.
 
 ### 2.7
+
 - Fixed gliding in Chrome v49+.
 
 ### 2.6
+
 - Allow the extension to be used on file paths.
 
 ### 2.5
+
 - Changed mouse cursor to grabbing when dragging. Thanks to [koMah](https://github.com/koMah).
 
 ### 2.4
+
 - Fixed compatibility issues related to Change Colors extension
 
 ### 2.3
+
 - Compatibility fixes for future versions of Chrome.
 
 ### 2.2
+
 - Now enables clicks on gmail buttons (and similar) when scrolling with left mouse button.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Scrollbar Anywhere
 
-### **HELP WANTED:** This extension is becoming unusable due to Chrome's [deprecations for extensions](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3), and I don't have the time to fix this. See https://github.com/davidparsson/scrollbar-anywhere/pull/78 for progress.
-
 An extension for Google Chrome that makes it possible to to scroll pages as if the scrollbar was right under your pointer. Just press the configured mouse button and move the mouse.
 
 If you want grab-and-drag style scrolling, just set it up in the options.
@@ -9,6 +7,10 @@ If you want grab-and-drag style scrolling, just set it up in the options.
 The extension is based on the [Wet Banana extension](https://github.com/jedediah/wetbanana) and inspired by Scrollbar Anywhere for Firefox.
 
 ## Change Log
+
+### 3.0
+
+- Support new versions of Chrome with Manifest V3
 
 ### 2.17
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,23 +1,21 @@
-module.exports = function(grunt) {
-
-  require('jit-grunt')(grunt);
+module.exports = function (grunt) {
+  require('jit-grunt')(grunt)
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     manifest: grunt.file.readJSON('src/manifest.json'),
     clean: {
-      build: ['build/']
+      build: ['build/'],
     },
     zip: {
       distrtibution: {
         src: ['src/**/*'],
-        dest: 'build/scrollbar_anywhere-<%= manifest.version %>.zip'
-      }
-    }
-  });
+        dest: 'build/scrollbar_anywhere-<%= manifest.version %>.zip',
+      },
+    },
+  })
 
-  grunt.registerTask('default', ['build']);
+  grunt.registerTask('default', ['build'])
 
-  grunt.registerTask('build', ['clean', 'zip']);
-
-};
+  grunt.registerTask('build', ['clean', 'zip'])
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,148 +1,208 @@
 {
+  "name": "scrollbar-anywhere",
+  "lockfileVersion": 3,
   "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "abbrev": {
+  "packages": {
+    "": {
+      "devDependencies": {
+        "grunt": "^0.4.5",
+        "grunt-contrib-clean": "^0.7.0",
+        "grunt-zip": "^0.16.2",
+        "jit-grunt": "^0.9.1",
+        "prettier": "^3.3.0"
+      }
+    },
+    "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "argparse": {
+    "node_modules/argparse": {
       "version": "0.1.16",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
       "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "underscore": "~1.7.0",
         "underscore.string": "~2.4.0"
-      },
-      "dependencies": {
-        "underscore.string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
-          "dev": true
-        }
       }
     },
-    "async": {
+    "node_modules/argparse/node_modules/underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async": {
       "version": "0.1.22",
       "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
       "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "coffee-script": {
+    "node_modules/coffee-script": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
       "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
-      "dev": true
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "colors": {
+    "node_modules/colors": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
       "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
-    "dateformat": {
+    "node_modules/dateformat": {
       "version": "1.0.2-1.2.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
       "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "esprima": {
+    "node_modules/esprima": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
       "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "eventemitter2": {
+    "node_modules/eventemitter2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
-    "exit": {
+    "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
-    "findup-sync": {
+    "node_modules/findup-sync": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
       "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "glob": "~3.2.9",
         "lodash": "~2.4.1"
       },
-      "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true,
-          "requires": {
-            "inherits": "2",
-            "minimatch": "0.3"
-          }
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
-    "getobject": {
+    "node_modules/findup-sync/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/findup-sync/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/findup-sync/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/getobject": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "3.1.21",
       "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
       "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "graceful-fs": "~1.2.0",
         "inherits": "1",
         "minimatch": "~0.2.11"
       },
-      "dependencies": {
-        "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-          "dev": true
-        }
+      "engines": {
+        "node": "*"
       }
     },
-    "graceful-fs": {
+    "node_modules/glob/node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+      "dev": true
+    },
+    "node_modules/graceful-fs": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
       "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-      "dev": true
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "grunt": {
+    "node_modules/grunt": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "async": "~0.1.22",
         "coffee-script": "~1.3.3",
         "colors": "~0.6.2",
@@ -163,75 +223,100 @@
         "rimraf": "~2.2.8",
         "underscore.string": "~2.2.1",
         "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "grunt-contrib-clean": {
+    "node_modules/grunt-contrib-clean": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.7.0.tgz",
       "integrity": "sha1-EvynC79SW5GLc+XMsUUPQ762Kc0=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "rimraf": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "grunt": ">=0.4.0"
       }
     },
-    "grunt-legacy-log": {
+    "node_modules/grunt-legacy-log": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
       "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "colors": "~0.6.2",
         "grunt-legacy-log-utils": "~0.1.1",
         "hooker": "~0.2.3",
         "lodash": "~2.4.1",
         "underscore.string": "~2.3.3"
       },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "grunt-legacy-log-utils": {
+    "node_modules/grunt-legacy-log-utils": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
       "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "colors": "~0.6.2",
         "lodash": "~2.4.1",
         "underscore.string": "~2.3.3"
       },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "grunt-legacy-util": {
+    "node_modules/grunt-legacy-log-utils/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-log/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/grunt-legacy-log/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-util": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
       "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "async": "~0.1.22",
         "exit": "~0.1.1",
         "getobject": "~0.1.0",
@@ -239,133 +324,202 @@
         "lodash": "~0.9.2",
         "underscore.string": "~2.2.1",
         "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "grunt-retro": {
+    "node_modules/grunt-retro": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/grunt-retro/-/grunt-retro-0.6.4.tgz",
       "integrity": "sha1-8mqEj2pHl6X/foUOYCIMDea+jnI=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
-    "grunt-zip": {
+    "node_modules/grunt-zip": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/grunt-zip/-/grunt-zip-0.16.2.tgz",
       "integrity": "sha1-1p9qHJ/RA8AjdusdAht3MONa15o=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "grunt-retro": "~0.6.0",
         "jszip": "~2.2.2"
+      },
+      "bin": {
+        "grunt-zip": "bin/grunt-zip"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "hooker": {
+    "node_modules/hooker": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "iconv-lite": {
+    "node_modules/iconv-lite": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
       "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "jit-grunt": {
+    "node_modules/jit-grunt": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.9.1.tgz",
       "integrity": "sha1-9mKT31f+Nz7sA9aVTRlmFmNAYZM=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
     },
-    "js-yaml": {
+    "node_modules/js-yaml": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
       "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "argparse": "~ 0.1.11",
         "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
-    "jszip": {
+    "node_modules/jszip": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.2.2.tgz",
       "integrity": "sha1-T/2cpr15CralnECrjeKhMps0c0E=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "pako": "~0.2.1"
       }
     },
-    "lodash": {
+    "node_modules/lodash": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
       "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-      "dev": true
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ]
     },
-    "lru-cache": {
+    "node_modules/lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
       "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "lru-cache": "2",
         "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "nopt": {
+    "node_modules/nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "pako": {
+    "node_modules/pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
-    "rimraf": {
+    "node_modules/prettier": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
+      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/rimraf": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-      "dev": true
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "bin": {
+        "rimraf": "bin.js"
+      }
     },
-    "sigmund": {
+    "node_modules/sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
-    "underscore": {
+    "node_modules/underscore": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
       "dev": true
     },
-    "underscore.string": {
+    "node_modules/underscore.string": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
       "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "which": {
+    "node_modules/which": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
       "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "which": "bin/which"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.7.0",
     "grunt-zip": "^0.16.2",
-    "jit-grunt": "^0.9.1"
+    "jit-grunt": "^0.9.1",
+    "prettier": "^3.3.0"
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -1,23 +1,22 @@
-defaultOptions = { "button":    2,
-                   "key_shift": false,
-                   "key_ctrl":  false,
-                   "key_alt":   false,
-                   "key_meta":  false,
-                   "scaling":   1,
-                   "speed":     6000,
-                   "friction":  10,
-                   "cursor":    true,
-                   "notext":    false,
-                   "grab_and_drag": false,
-                   "debug":     false,
-                   "blacklist": "",
-                   "browser_enabled": true,
-                 }
+defaultOptions = {
+  button: 2,
+  key_shift: false,
+  key_ctrl: false,
+  key_alt: false,
+  key_meta: false,
+  scaling: 1,
+  speed: 6000,
+  friction: 10,
+  cursor: true,
+  notext: false,
+  grab_and_drag: false,
+  debug: false,
+  blacklist: '',
+  browser_enabled: true,
+}
 
 for (var k in defaultOptions)
-  if (typeof localStorage[k] == 'undefined')
-    localStorage[k] = defaultOptions[k]
-
+  if (typeof localStorage[k] == 'undefined') localStorage[k] = defaultOptions[k]
 
 function loadOptions() {
   var o = {}
@@ -27,13 +26,13 @@ function loadOptions() {
 
 clients = {}
 
-chrome.extension.onConnect.addListener(function(port) {
+chrome.extension.onConnect.addListener(function (port) {
   port.postMessage({ saveOptions: localStorage })
-  var id = port.sender.tab.id + ":" + port.sender.frameId
-  console.log("connect: "+id)
+  var id = port.sender.tab.id + ':' + port.sender.frameId
+  console.log('connect: ' + id)
   clients[id] = port
-  port.onDisconnect.addListener(function() {
-    console.log("disconnect: "+id)
+  port.onDisconnect.addListener(function () {
+    console.log('disconnect: ' + id)
     delete clients[id]
   })
 })
@@ -48,16 +47,15 @@ function saveOptions(o) {
   }
 }
 
-chrome.browserAction.onClicked.addListener(function(tab) {
-  if (localStorage['browser_enabled'] == "true") {
-    localStorage['browser_enabled'] = "false"
-    chrome.browserAction.setIcon({path:"icon16dis.png"})
+chrome.browserAction.onClicked.addListener(function (tab) {
+  if (localStorage['browser_enabled'] == 'true') {
+    localStorage['browser_enabled'] = 'false'
+    chrome.browserAction.setIcon({ path: 'icon16dis.png' })
+  } else {
+    localStorage['browser_enabled'] = 'true'
+    chrome.browserAction.setIcon({ path: 'icon16.png' })
   }
-  else {
-    localStorage['browser_enabled'] = "true"
-    chrome.browserAction.setIcon({path:"icon16.png"})
-  }
-  saveOptions({o:'browser_enabled'})
+  saveOptions({ o: 'browser_enabled' })
 })
 
 // Inject content script into all existing tabs (doesn't work)

--- a/src/background.js
+++ b/src/background.js
@@ -113,17 +113,3 @@ chrome.storage.local.onChanged.addListener(function (changes, namespace) {
     }
   }
 })
-
-// Inject content script into all existing tabs (doesn't work)
-// This functionality requires
-//  "permissions": ["tabs"]
-// in manifest.json
-/*
-chrome.windows.getAll({populate:true}, function(wins) {
-  wins.forEach(function(win) {
-    win.tabs.forEach(function(tab) {
-      chrome.tabs.executeScript(tab.id,{file:"content.js",allFrames:true});
-    })
-  })
-})
-*/

--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,4 @@
-defaultOptions = {
+var defaultOptions = {
   button: 2,
   key_shift: false,
   key_ctrl: false,
@@ -24,7 +24,7 @@ function loadOptions() {
   return o
 }
 
-clients = {}
+var clients = {}
 
 chrome.extension.onConnect.addListener(function (port) {
   port.postMessage({ saveOptions: localStorage })

--- a/src/background.js
+++ b/src/background.js
@@ -47,13 +47,13 @@ function saveOptions(o) {
   }
 }
 
-chrome.browserAction.onClicked.addListener(function (tab) {
+chrome.action.onClicked.addListener(function (tab) {
   if (localStorage['browser_enabled'] == 'true') {
     localStorage['browser_enabled'] = 'false'
-    chrome.browserAction.setIcon({ path: 'icon16dis.png' })
+    chrome.action.setIcon({ path: 'icon16dis.png' })
   } else {
     localStorage['browser_enabled'] = 'true'
-    chrome.browserAction.setIcon({ path: 'icon16.png' })
+    chrome.action.setIcon({ path: 'icon16.png' })
   }
   saveOptions({ o: 'browser_enabled' })
 })

--- a/src/content.js
+++ b/src/content.js
@@ -1,44 +1,48 @@
-
-var ScrollbarAnywhere = (function() {
-
+var ScrollbarAnywhere = (function () {
   // === Options ===
 
-  var options = {debug:true, enabled:false}
+  var options = { debug: true, enabled: false }
 
   var port = chrome.extension.connect()
-  port.onMessage.addListener(function(msg) {
+  port.onMessage.addListener(function (msg) {
     if (msg.saveOptions) {
       options = msg.saveOptions
-      options.cursor = (options.cursor == "true")
-      options.notext = (options.notext == "true")
-      options.grab_and_drag = (options.grab_and_drag == "true")
-      options.debug = (options.debug == "true")
+      options.cursor = options.cursor == 'true'
+      options.notext = options.notext == 'true'
+      options.grab_and_drag = options.grab_and_drag == 'true'
+      options.debug = options.debug == 'true'
       options.enabled = isEnabled(options.blacklist)
-      options.browser_enabled = (options.browser_enabled == "true")
-      debug("saveOptions: ",options)
+      options.browser_enabled = options.browser_enabled == 'true'
+      debug('saveOptions: ', options)
     }
   })
 
   function isEnabled(blacklist) {
     if (!blacklist) {
-      return true;
+      return true
     }
-    var blacklistedHosts = blacklist.split('\n');
-    var hostname = document.location.hostname;
+    var blacklistedHosts = blacklist.split('\n')
+    var hostname = document.location.hostname
     for (var i = blacklistedHosts.length - 1; i >= 0; i--) {
-      var blacklistedHost = blacklistedHosts[i].trim();
-      if (hostname === blacklistedHost || hostname.endsWith('.' + blacklistedHost)) {
-        return false;
+      var blacklistedHost = blacklistedHosts[i].trim()
+      if (
+        hostname === blacklistedHost ||
+        hostname.endsWith('.' + blacklistedHost)
+      ) {
+        return false
       }
     }
-    return true;
+    return true
   }
 
   // === Debuggering ===
 
   function debug() {
     if (options.debug) {
-      console.debug.apply(console,["SA:"].concat(Array.prototype.slice.call(arguments)))
+      console.debug.apply(
+        console,
+        ['SA:'].concat(Array.prototype.slice.call(arguments)),
+      )
     }
   }
 
@@ -48,17 +52,16 @@ var ScrollbarAnywhere = (function() {
   function debugCont() {
     if (options.debug) {
       var now = Date.now()
-      if (lastDebug+DEBUG_INTERVAL <= now) {
+      if (lastDebug + DEBUG_INTERVAL <= now) {
         lastDebug = now
-        debug.apply(this,arguments)
+        debug.apply(this, arguments)
       }
     }
   }
 
-
   // === Util ===
 
-  String.prototype.padLeft = function(n,c) {
+  String.prototype.padLeft = function (n, c) {
     if (!c) c = ' '
     var a = []
     for (var i = this.length; i < n; i++) a.push(c)
@@ -71,44 +74,64 @@ var ScrollbarAnywhere = (function() {
   }
 
   function formatVector(v) {
-    return "["+formatCoord(v[0])+","+formatCoord(v[1])+"]"
+    return '[' + formatCoord(v[0]) + ',' + formatCoord(v[1]) + ']'
   }
-
 
   // === Vector math ===
 
-  function vadd(a,b)   { return [a[0]+b[0], a[1]+b[1]] }
-  function vsub(a,b)   { return [a[0]-b[0], a[1]-b[1]] }
-  function vmul(s,v)   { return [s*v[0], s*v[1]] }
-  function vdiv(s,v)   { return [v[0]/s, v[1]/s] }
-  function vmag2(v)    { return v[0]*v[0] + v[1]*v[1] }
-  function vmag(v)     { return Math.sqrt(v[0]*v[0] + v[1]*v[1]) }
-  function vunit(v)    { return vdiv(vmag(v),v) }
-
+  function vadd(a, b) {
+    return [a[0] + b[0], a[1] + b[1]]
+  }
+  function vsub(a, b) {
+    return [a[0] - b[0], a[1] - b[1]]
+  }
+  function vmul(s, v) {
+    return [s * v[0], s * v[1]]
+  }
+  function vdiv(s, v) {
+    return [v[0] / s, v[1] / s]
+  }
+  function vmag2(v) {
+    return v[0] * v[0] + v[1] * v[1]
+  }
+  function vmag(v) {
+    return Math.sqrt(v[0] * v[0] + v[1] * v[1])
+  }
+  function vunit(v) {
+    return vdiv(vmag(v), v)
+  }
 
   // Test if the given point is directly over text
-  var isOverText = (function() {
-    var bonet = document.createElement("SPAN")
-    return function(ev) {
+  var isOverText = (function () {
+    var bonet = document.createElement('SPAN')
+    return function (ev) {
       var mommy = ev.target
       if (mommy == null) return false
       for (var i = 0; i < mommy.childNodes.length; i++) {
         var baby = mommy.childNodes[i]
-        if (baby.nodeType == Node.TEXT_NODE && baby.textContent.search(/\S/) != -1) {
+        if (
+          baby.nodeType == Node.TEXT_NODE &&
+          baby.textContent.search(/\S/) != -1
+        ) {
           // debug("TEXT_NODE: '"+baby.textContent+"'")
           try {
-            bonet.appendChild(mommy.replaceChild(bonet,baby))
-            if (bonet.isSameNode(document.elementFromPoint(ev.clientX,ev.clientY))) return true
+            bonet.appendChild(mommy.replaceChild(bonet, baby))
+            if (
+              bonet.isSameNode(
+                document.elementFromPoint(ev.clientX, ev.clientY),
+              )
+            )
+              return true
           } finally {
             if (baby.isSameNode(bonet.firstChild)) bonet.removeChild(baby)
-            if (bonet.isSameNode(mommy.childNodes[i])) mommy.replaceChild(baby,bonet)
+            if (bonet.isSameNode(mommy.childNodes[i]))
+              mommy.replaceChild(baby, bonet)
           }
         }
       }
       return false
     }
   })()
-
 
   /*
   large <html>.clientHeight:
@@ -126,30 +149,36 @@ var ScrollbarAnywhere = (function() {
   // The body element is treated separately since the visible size is
   // fetched differently depending on the doctype.
   function isOverScrollbar(ev) {
-    var t = ev.target == document.documentElement ? document.scrollingElement : ev.target;
+    var t =
+      ev.target == document.documentElement
+        ? document.scrollingElement
+        : ev.target
     if (t == document.scrollingElement) {
-      var d = document.documentElement;
-      var clientWidth;
-      var clientHeight;
-      if (d.scrollHeight == d.clientHeight && d.scrollHeight == d.offsetHeight) {
+      var d = document.documentElement
+      var clientWidth
+      var clientHeight
+      if (
+        d.scrollHeight == d.clientHeight &&
+        d.scrollHeight == d.offsetHeight
+      ) {
         // Guessing it's a no doctype document
-        clientWidth = t.clientWidth;
-        clientHeight = t.clientHeight;
+        clientWidth = t.clientWidth
+        clientHeight = t.clientHeight
+      } else {
+        clientWidth = d.clientWidth
+        clientHeight = d.clientHeight
       }
-      else {
-        clientWidth = d.clientWidth;
-        clientHeight = d.clientHeight;
-      }
-      return (ev.offsetX - t.scrollLeft >= clientWidth ||
-              ev.offsetY - t.scrollTop >= clientHeight);
-    }
-    else if (!isScrollable(t)) {
-      return false;
-    }
-    else
-    {
-      return (ev.offsetX - t.scrollLeft >= t.clientWidth ||
-              ev.offsetY - t.scrollTop >= t.clientHeight);
+      return (
+        ev.offsetX - t.scrollLeft >= clientWidth ||
+        ev.offsetY - t.scrollTop >= clientHeight
+      )
+    } else if (!isScrollable(t)) {
+      return false
+    } else {
+      return (
+        ev.offsetX - t.scrollLeft >= t.clientWidth ||
+        ev.offsetY - t.scrollTop >= t.clientHeight
+      )
     }
   }
 
@@ -159,19 +188,20 @@ var ScrollbarAnywhere = (function() {
   function isScrollable(e) {
     var o
     if (e.scrollWidth > e.clientWidth) {
-      o = document.defaultView.getComputedStyle(e)["overflow-x"]
-      if (o == "auto" || o == "scroll") return true
+      o = document.defaultView.getComputedStyle(e)['overflow-x']
+      if (o == 'auto' || o == 'scroll') return true
     }
     if (e.scrollHeight > e.clientHeight) {
-      o = document.defaultView.getComputedStyle(e)["overflow-y"]
-      if (o == "auto" || o == "scroll") return true
+      o = document.defaultView.getComputedStyle(e)['overflow-y']
+      if (o == 'auto' || o == 'scroll') return true
     }
     return false
   }
 
   // Return the first ancestor (or the element itself) that is scrollable
   function findInnermostScrollable(e) {
-    if (e == document.documentElement || e == document.body) return document.scrollingElement
+    if (e == document.documentElement || e == document.body)
+      return document.scrollingElement
     if (e == null || e == document.scrollingElement || isScrollable(e)) {
       return e
     } else {
@@ -180,34 +210,59 @@ var ScrollbarAnywhere = (function() {
   }
 
   // Don't drag when left-clicking on these elements
-  const LBUTTON_OVERRIDE_TAGS = ['A','INPUT','SELECT','TEXTAREA','BUTTON','LABEL','OBJECT','EMBED']
+  const LBUTTON_OVERRIDE_TAGS = [
+    'A',
+    'INPUT',
+    'SELECT',
+    'TEXTAREA',
+    'BUTTON',
+    'LABEL',
+    'OBJECT',
+    'EMBED',
+  ]
   const MBUTTON_OVERRIDE_TAGS = ['A']
-  const RBUTTON_OVERRIDE_TAGS = ['A','INPUT','TEXTAREA','OBJECT','EMBED']
+  const RBUTTON_OVERRIDE_TAGS = ['A', 'INPUT', 'TEXTAREA', 'OBJECT', 'EMBED']
   function hasOverrideAncestor(e) {
     if (e == null) return false
-    if (options.button == LBUTTON && shouldOverrideLeftButton(e)) return true;
-    if (options.button == MBUTTON && MBUTTON_OVERRIDE_TAGS.some(function(tag) { return tag == e.tagName })) return true
-    if (options.button == RBUTTON && RBUTTON_OVERRIDE_TAGS.some(function(tag) { return tag == e.tagName })) return true
+    if (options.button == LBUTTON && shouldOverrideLeftButton(e)) return true
+    if (
+      options.button == MBUTTON &&
+      MBUTTON_OVERRIDE_TAGS.some(function (tag) {
+        return tag == e.tagName
+      })
+    )
+      return true
+    if (
+      options.button == RBUTTON &&
+      RBUTTON_OVERRIDE_TAGS.some(function (tag) {
+        return tag == e.tagName
+      })
+    )
+      return true
     return arguments.callee(e.parentNode)
   }
 
   function shouldOverrideLeftButton(e) {
-    return LBUTTON_OVERRIDE_TAGS.some(function(tag) { return tag == e.tagName; }) || hasRoleButtonAttribute(e);
+    return (
+      LBUTTON_OVERRIDE_TAGS.some(function (tag) {
+        return tag == e.tagName
+      }) || hasRoleButtonAttribute(e)
+    )
   }
 
   function hasRoleButtonAttribute(e) {
     if (e.attributes && e.attributes.role) {
-      return e.attributes.role.value === 'button';
+      return e.attributes.role.value === 'button'
     }
-    return false;
+    return false
   }
 
   // === Clipboard Stuff ===
-  var Clipboard = (function(){
+  var Clipboard = (function () {
     var blockElement = null
 
     function isPastable(e) {
-      return e && e.tagName == 'INPUT' || e.tagName == 'TEXTAREA'
+      return (e && e.tagName == 'INPUT') || e.tagName == 'TEXTAREA'
     }
 
     // Block the next paste event if a text element is active. This is a
@@ -217,17 +272,17 @@ var ScrollbarAnywhere = (function() {
       if (blockElement != e) {
         if (blockElement) unblockPaste()
         if (isPastable(e)) {
-          debug("blocking paste for active text element", e)
+          debug('blocking paste for active text element', e)
           blockElement = e
-          e.addEventListener('paste',onPaste,true)
+          e.addEventListener('paste', onPaste, true)
         }
       }
     }
 
     function unblockPaste() {
       if (blockElement) {
-        debug("unblocking paste", blockElement)
-        blockElement.removeEventListener('paste',onPaste,true)
+        debug('unblocking paste', blockElement)
+        blockElement.removeEventListener('paste', onPaste, true)
         blockElement = null
       }
     }
@@ -239,87 +294,88 @@ var ScrollbarAnywhere = (function() {
           blockElement = null
           ev.preventDefault()
         }
-        e.removeEventListener('paste',arguments.callee,true)
+        e.removeEventListener('paste', arguments.callee, true)
       }
     }
 
-    return { blockPaste: blockPaste,
-             unblockPaste: unblockPaste }
+    return { blockPaste: blockPaste, unblockPaste: unblockPaste }
   })()
 
   // === Scrollfix hack ===
-  var ScrollFix = (function(){
-    var scrollFixElement = null;
-    var showingScrollFix = false;
+  var ScrollFix = (function () {
+    var scrollFixElement = null
+    var showingScrollFix = false
 
     function createScrollFix() {
-      var element = document.createElement('div');
-      element.setAttribute('style', 'background: transparent none !important');
-      element.style.position = 'fixed';
-      element.style.top=0;
-      element.style.right=0;
-      element.style.bottom=0;
-      element.style.left=0;
-      element.style.zIndex=99999999;
-      element.style.display='block';
+      var element = document.createElement('div')
+      element.setAttribute('style', 'background: transparent none !important')
+      element.style.position = 'fixed'
+      element.style.top = 0
+      element.style.right = 0
+      element.style.bottom = 0
+      element.style.left = 0
+      element.style.zIndex = 99999999
+      element.style.display = 'block'
       //element.style.borderRight='5px solid rgba(0,0,0,0.04)';
-      return element;
+      return element
     }
 
     function show() {
       if (scrollFixElement === null) {
-        scrollFixElement = createScrollFix();
+        scrollFixElement = createScrollFix()
       }
       if (!showingScrollFix) {
-        debug("showing scrollfix")
-        document.body.appendChild(scrollFixElement);
-        showingScrollFix = true;
+        debug('showing scrollfix')
+        document.body.appendChild(scrollFixElement)
+        showingScrollFix = true
       }
     }
 
     function hide() {
-      if (showingScrollFix && scrollFixElement !== null && scrollFixElement.parentNode !== null) {
-        debug("hiding scrollfix")
-        scrollFixElement.parentNode.removeChild(scrollFixElement);
-        showingScrollFix = false;
+      if (
+        showingScrollFix &&
+        scrollFixElement !== null &&
+        scrollFixElement.parentNode !== null
+      ) {
+        debug('hiding scrollfix')
+        scrollFixElement.parentNode.removeChild(scrollFixElement)
+        showingScrollFix = false
       }
     }
 
-    return { show: show,
-             hide: hide }
-  })();
+    return { show: show, hide: hide }
+  })()
 
   // === Fake Selection ===
 
-  var Selector = (function(){
-
+  var Selector = (function () {
     var startRange = null
 
-    function start(x,y) {
-      debug("Selector.start("+x+","+y+")")
-      startRange = document.caretRangeFromPoint(x,y)
+    function start(x, y) {
+      debug('Selector.start(' + x + ',' + y + ')')
+      startRange = document.caretRangeFromPoint(x, y)
       var s = getSelection()
       s.removeAllRanges()
       s.addRange(startRange)
     }
 
-    function update(x,y) {
-      debug("Selector.update("+x+","+y+")")
+    function update(x, y) {
+      debug('Selector.update(' + x + ',' + y + ')')
 
-           if (y < 0) y = 0
-      else if (y >= innerHeight) y = innerHeight-1
-           if (x < 0) x = 0
-      else if (x >= innerWidth) x = innerWidth-1
+      if (y < 0) y = 0
+      else if (y >= innerHeight) y = innerHeight - 1
+      if (x < 0) x = 0
+      else if (x >= innerWidth) x = innerWidth - 1
 
-      if (!startRange) start(x,y)
+      if (!startRange) start(x, y)
       var a = startRange
-      var b = document.caretRangeFromPoint(x,y)
+      var b = document.caretRangeFromPoint(x, y)
 
       if (b != null) {
-        if (b.compareBoundaryPoints(Range.START_TO_START,a) > 0) {
-          b.setStart(a.startContainer,a.startOffset)
+        if (b.compareBoundaryPoints(Range.START_TO_START, a) > 0) {
+          b.setStart(a.startContainer, a.startOffset)
         } else {
-          b.setEnd(a.startContainer,a.startOffset)
+          b.setEnd(a.startContainer, a.startOffset)
         }
 
         var s = getSelection()
@@ -329,7 +385,7 @@ var ScrollbarAnywhere = (function() {
     }
 
     function cancel() {
-      debug("Selector.cancel()")
+      debug('Selector.cancel()')
       startRange = null
       getSelection().removeAllRanges()
     }
@@ -337,29 +393,25 @@ var ScrollbarAnywhere = (function() {
     function scroll(ev) {
       var y = ev.clientY
       if (y < 0) {
-        scrollBy(0,y)
+        scrollBy(0, y)
         return true
       } else if (y >= innerHeight) {
-        scrollBy(0,y-innerHeight)
+        scrollBy(0, y - innerHeight)
         return true
       }
       return false
     }
 
-    return { start: start,
-             update: update,
-             cancel: cancel,
-             scroll: scroll }
+    return { start: start, update: update, cancel: cancel, scroll: scroll }
   })()
-
 
   // === Motion ===
 
-  var Motion = (function() {
+  var Motion = (function () {
     const MIN_SPEED_SQUARED = 1
     const FILTER_INTERVAL = 100
     var position = null
-    var velocity = [0,0]
+    var velocity = [0, 0]
     var updateTime = null
     var impulses = []
 
@@ -368,10 +420,10 @@ var ScrollbarAnywhere = (function() {
     function clamp() {
       var speedSquared = vmag2(velocity)
       if (speedSquared <= MIN_SPEED_SQUARED) {
-        velocity = [0,0]
+        velocity = [0, 0]
         return false
-      } else if (speedSquared > options.speed*options.speed) {
-        velocity = vmul(options.speed,vunit(velocity))
+      } else if (speedSquared > options.speed * options.speed) {
+        velocity = vmul(options.speed, vunit(velocity))
       }
       return true
     }
@@ -379,27 +431,27 @@ var ScrollbarAnywhere = (function() {
     // zero velocity
     function stop() {
       impulses = []
-      velocity = [0,0]
+      velocity = [0, 0]
     }
 
     // impulsively move to given position and time
     // return if/not there is motion
-    function impulse(pos,time) {
+    function impulse(pos, time) {
       position = pos
       updateTime = time
 
-      while (impulses.length > 0 && (time - impulses[0].time) > FILTER_INTERVAL) impulses.shift()
-      impulses.push({pos:pos,time:time})
+      while (impulses.length > 0 && time - impulses[0].time > FILTER_INTERVAL)
+        impulses.shift()
+      impulses.push({ pos: pos, time: time })
 
       if (impulses.length < 2) {
-        velocity = [0,0]
+        velocity = [0, 0]
         return false
       } else {
         var a = impulses[0]
-        var b = impulses[impulses.length-1]
+        var b = impulses[impulses.length - 1]
 
-        velocity = vdiv((b.time - a.time)/1000,
-                        vsub(b.pos,a.pos))
+        velocity = vdiv((b.time - a.time) / 1000, vsub(b.pos, a.pos))
         return clamp()
       }
     }
@@ -413,34 +465,43 @@ var ScrollbarAnywhere = (function() {
       if (updateTime == null) {
         moving = false
       } else {
-        var deltaSeconds = (time-updateTime)/1000;
-        var frictionMultiplier = Math.max(1-(options.friction/FILTER_INTERVAL), 0);
-        frictionMultiplier = Math.pow(frictionMultiplier, deltaSeconds*FILTER_INTERVAL);
-        velocity = vmul(frictionMultiplier, velocity);
+        var deltaSeconds = (time - updateTime) / 1000
+        var frictionMultiplier = Math.max(
+          1 - options.friction / FILTER_INTERVAL,
+          0,
+        )
+        frictionMultiplier = Math.pow(
+          frictionMultiplier,
+          deltaSeconds * FILTER_INTERVAL,
+        )
+        velocity = vmul(frictionMultiplier, velocity)
         moving = clamp()
-        position = vadd(position,vmul(deltaSeconds,velocity))
+        position = vadd(position, vmul(deltaSeconds, velocity))
       }
       updateTime = time
       return moving
     }
 
-    function getPosition() { return position }
+    function getPosition() {
+      return position
+    }
 
-    return { stop: stop,
-             impulse: impulse,
-             glide: glide,
-             getPosition: getPosition }
+    return {
+      stop: stop,
+      impulse: impulse,
+      glide: glide,
+      getPosition: getPosition,
+    }
   })()
 
-
-  var Scroll = (function() {
+  var Scroll = (function () {
     var scrolling = false
     var element
     var scrollOrigin
     var viewportSize
     var scrollSize
     var scrollListener
-    var scrollMultiplier;
+    var scrollMultiplier
 
     // Return the size of the element as it appears in parent's layout
     function getViewportSize(el) {
@@ -459,14 +520,13 @@ var ScrollbarAnywhere = (function() {
       scrollSize = [el.scrollWidth, el.scrollHeight]
       scrollOrigin = [el.scrollLeft, el.scrollTop]
       if (options.grab_and_drag) {
-        scrollMultiplier = [-options.scaling,
-                            -options.scaling];
+        scrollMultiplier = [-options.scaling, -options.scaling]
+      } else {
+        scrollMultiplier = [
+          (scrollSize[0] / viewportSize[0]) * 1.15 * options.scaling,
+          (scrollSize[1] / viewportSize[1]) * 1.15 * options.scaling,
+        ]
       }
-      else {
-        scrollMultiplier = [(scrollSize[0] / viewportSize[0]) * 1.15 * options.scaling,
-                            (scrollSize[1] / viewportSize[1]) * 1.15 * options.scaling];
-      }
-
     }
 
     // Move the currently dragged element relative to the starting position
@@ -479,8 +539,8 @@ var ScrollbarAnywhere = (function() {
         var y = element.scrollTop
         try {
           scrolling = true
-          element.scrollLeft = scrollOrigin[0] + pos[0] * scrollMultiplier[0];
-          element.scrollTop  = scrollOrigin[1] + pos[1] * scrollMultiplier[1];
+          element.scrollLeft = scrollOrigin[0] + pos[0] * scrollMultiplier[0]
+          element.scrollTop = scrollOrigin[1] + pos[1] * scrollMultiplier[1]
         } finally {
           scrolling = false
         }
@@ -502,20 +562,21 @@ var ScrollbarAnywhere = (function() {
       scrollListener = fn
     }
 
-    return { start: start,
-             move: move,
-             stop: stop,
-             listen: listen }
+    return { start: start, move: move, stop: stop, listen: listen }
   })()
 
-
-  const LBUTTON=0, MBUTTON=1, RBUTTON=2
-  const KEYS = ["shift","ctrl","alt","meta"]
-  const KEYS_KEY_CODES = [16,17,18,91,92]
+  const LBUTTON = 0,
+    MBUTTON = 1,
+    RBUTTON = 2
+  const KEYS = ['shift', 'ctrl', 'alt', 'meta']
+  const KEYS_KEY_CODES = [16, 17, 18, 91, 92]
   const TIME_STEP = 10
 
-  const STOP=0, CLICK=1, DRAG=2, GLIDE=3
-  const ACTIVITIES = ["STOP","CLICK","DRAG","GLIDE"]
+  const STOP = 0,
+    CLICK = 1,
+    DRAG = 2,
+    GLIDE = 3
+  const ACTIVITIES = ['STOP', 'CLICK', 'DRAG', 'GLIDE']
   for (var i = 0; i < ACTIVITIES.length; i++) window[ACTIVITIES[i]] = i
 
   var activity = STOP
@@ -525,55 +586,54 @@ var ScrollbarAnywhere = (function() {
 
   function updateGlide() {
     if (activity == GLIDE) {
-      debug("glide update");
-      var moving = Motion.glide(performance.now());
-      moving = Scroll.move(vsub(Motion.getPosition(),mouseOrigin)) && moving;
+      debug('glide update')
+      var moving = Motion.glide(performance.now())
+      moving = Scroll.move(vsub(Motion.getPosition(), mouseOrigin)) && moving
       if (moving) {
-        setTimeout(updateGlide,TIME_STEP);
+        setTimeout(updateGlide, TIME_STEP)
       } else {
-        stopGlide();
+        stopGlide()
       }
     }
   }
 
   function stopGlide() {
-    debug("glide stop")
+    debug('glide stop')
     activity = STOP
     Motion.stop()
     Scroll.stop()
   }
 
   function updateDrag(ev) {
-    debug("drag update")
-    var v = [ev.clientX,ev.clientY]
+    debug('drag update')
+    var v = [ev.clientX, ev.clientY]
     var moving = false
-    if (v[0] && v[1])
-    {
-      moving = Motion.impulse(v,ev.timeStamp)
-      Scroll.move(vsub(v,mouseOrigin))
+    if (v[0] && v[1]) {
+      moving = Motion.impulse(v, ev.timeStamp)
+      Scroll.move(vsub(v, mouseOrigin))
     }
     return moving
   }
 
   function startDrag(ev) {
-    debug("drag start")
+    debug('drag start')
     activity = DRAG
     if (options.cursor) {
-      document.body.style.cursor = "-webkit-grabbing";
-      document.body.style.cursor = "-moz-grabbing";
-      document.body.style.cursor = "grabbing";
+      document.body.style.cursor = '-webkit-grabbing'
+      document.body.style.cursor = '-moz-grabbing'
+      document.body.style.cursor = 'grabbing'
     }
     Scroll.start(dragElement)
     return updateDrag(ev)
   }
 
   function stopDrag(ev) {
-    debug("drag stop")
-    if (options.cursor) document.body.style.cursor = "auto"
+    debug('drag stop')
+    if (options.cursor) document.body.style.cursor = 'auto'
     Clipboard.unblockPaste()
     ScrollFix.hide()
     if (updateDrag(ev)) {
-      window.setTimeout(updateGlide,TIME_STEP)
+      window.setTimeout(updateGlide, TIME_STEP)
       activity = GLIDE
     } else {
       Scroll.stop()
@@ -585,169 +645,186 @@ var ScrollbarAnywhere = (function() {
     blockContextMenu = false
 
     if (!options.enabled) {
-      debug("blacklisted domain, ignoring");
-      return true;
+      debug('blacklisted domain, ignoring')
+      return true
     }
 
     if (!options.browser_enabled) {
-      debug("browserAction is disabled, ignoring")
-      return true;
+      debug('browserAction is disabled, ignoring')
+      return true
     }
 
     switch (activity) {
-
-    case GLIDE:
-      stopGlide(ev)
+      case GLIDE:
+        stopGlide(ev)
       // fall through
 
-    case STOP:
-      if (!ev.target) {
-        debug("target is null, ignoring")
+      case STOP:
+        if (!ev.target) {
+          debug('target is null, ignoring')
+          break
+        }
+
+        if (ev.button != options.button) {
+          debug(
+            'wrong button, ignoring   ev.button=' +
+              ev.button +
+              '   options.button=' +
+              options.button,
+          )
+          break
+        }
+
+        if (
+          !KEYS.every(function (key) {
+            return (options['key_' + key] + '' == 'true') == ev[key + 'Key']
+          })
+        ) {
+          debug('wrong modkeys, ignoring')
+          break
+        }
+
+        if (hasOverrideAncestor(ev.target)) {
+          debug('forbidden target element, ignoring', ev)
+          break
+        }
+
+        if (isOverScrollbar(ev)) {
+          debug('detected scrollbar click, ignoring', ev)
+          break
+        }
+
+        dragElement = findInnermostScrollable(ev.target)
+        if (!dragElement) {
+          debug('no scrollable ancestor found, ignoring', ev)
+          break
+        }
+
+        if (options.notext && isOverText(ev)) {
+          debug('detected text node, ignoring')
+          break
+        }
+
+        debug('click MouseEvent=', ev, ' dragElement=', dragElement)
+        activity = CLICK
+        mouseOrigin = [ev.clientX, ev.clientY]
+        Motion.impulse(mouseOrigin, ev.timeStamp)
+        ev.preventDefault()
+        if (ev.button == MBUTTON && ev.target != document.activeElement)
+          Clipboard.blockPaste()
+        if (
+          ev.button == RBUTTON &&
+          (navigator.platform.match(/Mac/) || navigator.platform.match(/Linux/))
+        ) {
+          blockContextMenu = true
+        }
         break
-      }
 
-      if (ev.button != options.button) {
-        debug("wrong button, ignoring   ev.button="+ev.button+"   options.button="+options.button)
-        break
-      }
-
-      if (!KEYS.every(function(key) { return (options['key_'+key]+'' == 'true') == ev[key+"Key"] })) {
-        debug("wrong modkeys, ignoring")
-        break
-      }
-
-      if (hasOverrideAncestor(ev.target)) {
-        debug("forbidden target element, ignoring",ev)
-        break
-      }
-
-      if (isOverScrollbar(ev)) {
-        debug("detected scrollbar click, ignoring",ev)
-        break
-      }
-
-      dragElement = findInnermostScrollable(ev.target)
-      if (!dragElement) {
-        debug("no scrollable ancestor found, ignoring",ev)
-        break
-      }
-
-      if (options.notext && isOverText(ev)) {
-        debug("detected text node, ignoring")
-        break
-      }
-
-      debug("click MouseEvent=",ev," dragElement=",dragElement)
-      activity = CLICK
-      mouseOrigin = [ev.clientX,ev.clientY]
-      Motion.impulse(mouseOrigin,ev.timeStamp)
-      ev.preventDefault()
-      if (ev.button == MBUTTON &&
-          ev.target != document.activeElement) Clipboard.blockPaste()
-      if (ev.button == RBUTTON &&
-          (navigator.platform.match(/Mac/) || navigator.platform.match(/Linux/))) {
-        blockContextMenu = true;
-      }
-      break
-
-    default:
-      debug("WARNING: illegal activity for mousedown: "+ACTIVITIES[activity]);
-      if (options.cursor) document.body.style.cursor = "auto";
-      Clipboard.unblockPaste();
-      ScrollFix.hide();
-      activity = STOP;
-      return onMouseDown(ev);
+      default:
+        debug(
+          'WARNING: illegal activity for mousedown: ' + ACTIVITIES[activity],
+        )
+        if (options.cursor) document.body.style.cursor = 'auto'
+        Clipboard.unblockPaste()
+        ScrollFix.hide()
+        activity = STOP
+        return onMouseDown(ev)
     }
   }
 
   function onMouseMove(ev) {
     switch (activity) {
+      case STOP:
+        break
 
-    case STOP: break
-
-    case CLICK:
-      if (ev.buttons == buttonToMouseMoveButtons(options.button)) {
-        if (positionsWithinDistance(mouseOrigin, [ev.clientX, ev.clientY], 0)) {
-          debug("ignore, short drag")
-          break
+      case CLICK:
+        if (ev.buttons == buttonToMouseMoveButtons(options.button)) {
+          if (
+            positionsWithinDistance(mouseOrigin, [ev.clientX, ev.clientY], 0)
+          ) {
+            debug('ignore, short drag')
+            break
+          }
+          if (options.button == RBUTTON) blockContextMenu = true
+          ScrollFix.show()
+          startDrag(ev)
+          ev.preventDefault()
         }
-        if (options.button == RBUTTON) blockContextMenu = true
-        ScrollFix.show();
-        startDrag(ev)
-        ev.preventDefault()
-      }
-      break
+        break
 
-    case DRAG:
-      if (ev.buttons == buttonToMouseMoveButtons(options.button)) {
-        updateDrag(ev);
-        ev.preventDefault();
-      }
-      break;
+      case DRAG:
+        if (ev.buttons == buttonToMouseMoveButtons(options.button)) {
+          updateDrag(ev)
+          ev.preventDefault()
+        }
+        break
 
-    case GLIDE: break
+      case GLIDE:
+        break
 
-    default:
-      debug("WARNING: unknown state: "+activity)
-      break
+      default:
+        debug('WARNING: unknown state: ' + activity)
+        break
     }
   }
 
   function onMouseUp(ev) {
     switch (activity) {
+      case STOP:
+        break
 
-    case STOP: break
+      case CLICK:
+        debug('unclick, no drag')
+        Clipboard.unblockPaste()
+        ScrollFix.hide()
+        if (ev.button == 0) getSelection().removeAllRanges()
+        if (document.activeElement) document.activeElement.blur()
+        if (ev.target) ev.target.focus()
+        if (ev.button == options.button) activity = STOP
+        break
 
-    case CLICK:
-      debug("unclick, no drag")
-      Clipboard.unblockPaste()
-      ScrollFix.hide()
-      if (ev.button == 0) getSelection().removeAllRanges()
-      if (document.activeElement) document.activeElement.blur()
-      if (ev.target) ev.target.focus()
-      if (ev.button == options.button) activity = STOP
-      break
+      case DRAG:
+        if (ev.button == options.button) {
+          stopDrag(ev)
+          ev.preventDefault()
+        }
+        break
 
-    case DRAG:
-      if (ev.button == options.button) {
-        stopDrag(ev)
-        ev.preventDefault()
-      }
-      break
+      case GLIDE:
+        stopGlide(ev)
+        break
 
-    case GLIDE:
-      stopGlide(ev)
-      break
-
-    default:
-      debug("WARNING: unknown state: "+activity)
-      break
+      default:
+        debug('WARNING: unknown state: ' + activity)
+        break
     }
   }
 
   function onMouseOut(ev) {
     switch (activity) {
+      case STOP:
+        break
 
-    case STOP: break
+      case CLICK:
+        break
 
-    case CLICK: break
+      case DRAG:
+        if (ev.toElement == null) stopDrag(ev)
+        break
 
-    case DRAG:
-      if (ev.toElement == null) stopDrag(ev)
-      break
+      case GLIDE:
+        break
 
-    case GLIDE: break
-
-    default:
-      debug("WARNING: unknown state: "+activity)
-      break
+      default:
+        debug('WARNING: unknown state: ' + activity)
+        break
     }
   }
 
   function onContextMenu(ev) {
     if (blockContextMenu) {
       blockContextMenu = false
-      debug("blocking context menu")
+      debug('blocking context menu')
       ev.preventDefault()
     }
   }
@@ -759,36 +836,38 @@ var ScrollbarAnywhere = (function() {
 
   function onAbortingAction(ev) {
     switch (activity) {
+      case STOP:
+        break
 
-      case STOP: break
+      case CLICK:
+        break
 
-      case CLICK: break
-
-      case DRAG: break
+      case DRAG:
+        break
 
       case GLIDE:
         if (!KEYS_KEY_CODES.includes(ev.keyCode)) {
-          debug("key pressed or wheel scrolled while gliding")
+          debug('key pressed or wheel scrolled while gliding')
           stopGlide(ev)
         }
         break
 
       default:
-        debug("WARNING: unknown state: "+activity)
+        debug('WARNING: unknown state: ' + activity)
         break
-      }
+    }
   }
 
   return {
-    init: function() {
-      addEventListener("mousedown", onMouseDown, true)
-      addEventListener("mouseup", onMouseUp, true)
-      addEventListener("mousemove", onMouseMove, true)
-      addEventListener("mouseout", onMouseOut, true)
-      addEventListener("contextmenu", onContextMenu, true)
-      addEventListener("keydown", onAbortingAction, true)
-      addEventListener("wheel", onAbortingAction, true)
-    }
+    init: function () {
+      addEventListener('mousedown', onMouseDown, true)
+      addEventListener('mouseup', onMouseUp, true)
+      addEventListener('mousemove', onMouseMove, true)
+      addEventListener('mouseout', onMouseOut, true)
+      addEventListener('contextmenu', onContextMenu, true)
+      addEventListener('keydown', onAbortingAction, true)
+      addEventListener('wheel', onAbortingAction, true)
+    },
   }
 
   function buttonToMouseMoveButtons(button) {
@@ -797,7 +876,6 @@ var ScrollbarAnywhere = (function() {
     if (button == RBUTTON) return 2
     return 0
   }
-
 })()
 
 ScrollbarAnywhere.init()

--- a/src/content.js
+++ b/src/content.js
@@ -14,13 +14,12 @@ var ScrollbarAnywhere = (function () {
     debug('Loaded options: ', options)
   }
 
-  function loadOptions() {
-    chrome.storage.local.get(null, function (loadedOptions) {
-      debug('Trying to load options', loadedOptions)
-      if (Object.keys(loadedOptions).length > 0) {
-        parseLoadedOptions(loadedOptions)
-      }
-    })
+  async function loadOptions() {
+    const loadedOptions = await chrome.storage.local.get(null)
+    debug('Trying to load options', loadedOptions)
+    if (Object.keys(loadedOptions).length > 0) {
+      parseLoadedOptions(loadedOptions)
+    }
   }
 
   loadOptions()

--- a/src/content.js
+++ b/src/content.js
@@ -14,6 +14,14 @@ var ScrollbarAnywhere = (function () {
     debug('Loaded options: ', options)
   }
 
+  chrome.storage.local.onChanged.addListener(function (changes) {
+    debug('Stored options changed changed', changes)
+    for (var key in changes) {
+      options[key] = changes[key].newValue
+      parseLoadedOptions(options)
+    }
+  })
+
   async function loadOptions() {
     const loadedOptions = await chrome.storage.local.get(null)
     debug('Trying to load options', loadedOptions)
@@ -23,14 +31,6 @@ var ScrollbarAnywhere = (function () {
   }
 
   loadOptions()
-
-  chrome.storage.local.onChanged.addListener(function (changes) {
-    debug('Stored options changed changed', changes)
-    for (var key in changes) {
-      options[key] = changes[key].newValue
-      parseLoadedOptions(options)
-    }
-  })
 
   function isTrue(value) {
     return value == true || value == 'true'

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,7 @@
   "action": {
     "default_title": "Click to toggle Scrollbar Anywhere"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "offscreen"],
   "options_page": "options.html",
   "manifest_version": 3,
   "minimum_chrome_version": "49"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,6 +28,6 @@
   },
 
   "options_page": "options.html",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "minimum_chrome_version": "49"
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Scrollbar Anywhere",
-  "version": "2.17",
+  "version": "3.0",
   "description": "Click and drag anywhere to scroll the page.",
   "icons": {
     "128": "icon128.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,7 @@
   "background": {
     "scripts": ["background.js"]
   },
-  "browser_action": {
+  "action": {
     "default_title": "Click to toggle Scrollbar Anywhere"
   },
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,12 +10,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
       "all_frames": true,
       "run_at": "document_start"
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,12 +17,13 @@
     }
   ],
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js",
+    "type": "module"
   },
   "action": {
     "default_title": "Click to toggle Scrollbar Anywhere"
   },
-
+  "permissions": ["storage"],
   "options_page": "options.html",
   "manifest_version": 3,
   "minimum_chrome_version": "49"

--- a/src/offscreen.html
+++ b/src/offscreen.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Offscreen Worker</title>
+    <script src="offscreen.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/src/offscreen.js
+++ b/src/offscreen.js
@@ -1,0 +1,48 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const number = 'number'
+  const boolean = 'boolean'
+  const string = 'string'
+
+  const optionsToConvert = {
+    button: number,
+    key_shift: boolean,
+    key_ctrl: boolean,
+    key_alt: boolean,
+    key_meta: boolean,
+    scaling: number,
+    speed: number,
+    friction: number,
+    cursor: boolean,
+    notext: boolean,
+    grab_and_drag: boolean,
+    debug: boolean,
+    blacklist: string,
+    browser_enabled: boolean,
+  }
+
+  function parseOptions() {
+    const options = {}
+    Object.keys(optionsToConvert).forEach((key) => {
+      const value = localStorage.getItem(key)
+      console.log('Converting ', key, 'value:', value)
+      if (value !== null) {
+        if (optionsToConvert[key] === boolean) {
+          options[key] = value === 'true'
+        } else if (optionsToConvert[key] === number) {
+          options[key] = Number(value)
+        } else {
+          options[key] = value
+        }
+      }
+    })
+    return options
+  }
+
+  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.action === 'getOptionsFromLocalStorage') {
+      const options = parseOptions()
+      sendResponse(options)
+    }
+    return false
+  })
+})

--- a/src/options.html
+++ b/src/options.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>Scrollbar Anywhere</title>
@@ -19,9 +19,13 @@
         height: 24pt;
       }
 
-      h2 { margin: 0 }
+      h2 {
+        margin: 0;
+      }
 
-      div.backtotop { margin: 400px auto 0; }
+      div.backtotop {
+        margin: 400px auto 0;
+      }
 
       .centered {
         margin: auto;
@@ -43,25 +47,27 @@
       }
 
       a:visited {
-      	color: blue;
+        color: blue;
       }
     </style>
 
     <script src="content.js" type="text/javascript"></script>
     <script src="options.js" type="text/javascript"></script>
-
   </head>
   <body>
     <div class="centered-text">
       <a id="top"></a>
-      <table id="settings" class="centered" style="border: none; border-spacing: 16px;">
-
+      <table
+        id="settings"
+        class="centered"
+        style="border: none; border-spacing: 16px"
+      >
         <tr>
           <td class="setting_description">
             <h2>Button</h2>
             Which button will you hold down to drag?
           </td>
-          <td style="width:300px">
+          <td style="width: 300px">
             <select id="button">
               <option>Left</option>
               <option>Middle</option>
@@ -69,46 +75,67 @@
             </select>
 
             <div id="windows_middle_warning" class="tip" style="display: none">
-                WARNING: The middle button may not work on Windows due to a
-                <a href="http://code.google.com/p/chromium/issues/detail?id=17234">bug</a>
-                in the browser, which will be fixed in Chrome 5.
+              WARNING: The middle button may not work on Windows due to a
+              <a href="http://code.google.com/p/chromium/issues/detail?id=17234"
+                >bug</a
+              >
+              in the browser, which will be fixed in Chrome 5.
             </div>
-
           </td>
         </tr>
 
         <tr>
           <td class="setting_description">
-           <h2>Keys</h2>
-           Which extra keys will you hold down?
+            <h2>Keys</h2>
+            Which extra keys will you hold down?
           </td>
           <td>
             <table style="border: none">
-            <tr>
-              <td style="width:100px">
-                  <input id="key_shift" type="checkbox" /> <label for="key_shift">Shift</label></td>
-              <td><input id="key_ctrl"  type="checkbox" /> <label for="key_ctrl">Ctrl</label></td>
-            </tr>
-            <tr>
-              <td><input id="key_alt"   type="checkbox" /> <label for="key_alt">Alt</label></td>
-              <td><input id="key_meta"  type="checkbox" /> <label for="key_meta">Meta/Win/Tux</label></td>
-            </tr>
+              <tr>
+                <td style="width: 100px">
+                  <input id="key_shift" type="checkbox" />
+                  <label for="key_shift">Shift</label>
+                </td>
+                <td>
+                  <input id="key_ctrl" type="checkbox" />
+                  <label for="key_ctrl">Ctrl</label>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <input id="key_alt" type="checkbox" />
+                  <label for="key_alt">Alt</label>
+                </td>
+                <td>
+                  <input id="key_meta" type="checkbox" />
+                  <label for="key_meta">Meta/Win/Tux</label>
+                </td>
+              </tr>
             </table>
-            <div class="tip">Tip: any unchecked keys will <strong>disable</strong> dragging when held down</div>
+            <div class="tip">
+              Tip: any unchecked keys will <strong>disable</strong> dragging
+              when held down
+            </div>
           </td>
         </tr>
 
         <tr>
           <td></td>
           <td>
-            <label for="notext"><input id="notext" type="checkbox"/> Don't drag when clicking on text</label><br/>
+            <label for="notext"
+              ><input id="notext" type="checkbox" /> Don't drag when clicking on
+              text</label
+            ><br />
           </td>
         </tr>
 
         <tr>
           <td></td>
           <td>
-            <label for="cursor"><input id="cursor" type="checkbox"/> Change cursor while dragging</label><br/>
+            <label for="cursor"
+              ><input id="cursor" type="checkbox" /> Change cursor while
+              dragging</label
+            ><br />
             <div class="tip">Try unchecking this if you notice any delays</div>
           </td>
         </tr>
@@ -116,31 +143,38 @@
         <tr>
           <td class="setting_description">
             <h2>Grab and drag</h2>
-            Grab-and-drag style scrolling will be enabled instead of the scrollbar anywhere style.
+            Grab-and-drag style scrolling will be enabled instead of the
+            scrollbar anywhere style.
           </td>
           <td>
-            <label for="grab_and_drag"><input id="grab_and_drag" type="checkbox"/> Use Grab-and-drag style scrolling</label><br/>
+            <label for="grab_and_drag"
+              ><input id="grab_and_drag" type="checkbox" /> Use Grab-and-drag
+              style scrolling</label
+            ><br />
           </td>
         </tr>
 
         <tr>
           <td class="setting_description">
             <h2>Scaling</h2>
-            Mouse motion will be magnified by this factor. A negative number will invert scrolling. 100 is default.
+            Mouse motion will be magnified by this factor. A negative number
+            will invert scrolling. 100 is default.
           </td>
           <td>
-            <input id="scaling" type="text" style="width:60px" /> <sub>% of original scroll speed</sub>
+            <input id="scaling" type="text" style="width: 60px" />
+            <sub>% of original scroll speed</sub>
           </td>
         </tr>
-
 
         <tr>
           <td class="setting_description">
             <h2>Top Speed</h2>
-            The maximum speed at which the page will glide after you release it. Enter 0 to disable gliding.
+            The maximum speed at which the page will glide after you release it.
+            Enter 0 to disable gliding.
           </td>
           <td>
-            <input id="speed" type="text" style="width:60px" /> <sub>pixels per second</sub>
+            <input id="speed" type="text" style="width: 60px" />
+            <sub>pixels per second</sub>
           </td>
         </tr>
 
@@ -150,14 +184,16 @@
             How quickly the page will come to a stop when gliding.
           </td>
           <td>
-            <input id="friction" type="text" style="width:60px" /> <sub>velocities per second</sub>
+            <input id="friction" type="text" style="width: 60px" />
+            <sub>velocities per second</sub>
           </td>
         </tr>
 
         <tr>
           <td class="setting_description">
             <h2>Blacklist</h2>
-            Disable this extension on the configured domains and all of their subdomains.
+            Disable this extension on the configured domains and all of their
+            subdomains.
           </td>
           <td>
             <textarea id="blacklist" rows="5" cols="30"></textarea><br />
@@ -167,39 +203,101 @@
 
         <tr>
           <td></td>
-          <td><input id="debug" type="checkbox" /> <label for="debug">show debug noise in console</label></td>
+          <td>
+            <input id="debug" type="checkbox" />
+            <label for="debug">show debug noise in console</label>
+          </td>
         </tr>
 
         <tr>
           <td colspan="2" id="message" class="centered-text"></td>
         </tr>
-
       </table>
 
       <p>
         Scrollbar Anywhere by David P&auml;rsson -
         <a href="http://github.com/davidparsson/scrollbar-anywhere">Code</a> -
-        <a href="http://github.com/davidparsson/scrollbar-anywhere/issues">Support</a>
-        <br/> Based on <a href="https://chrome.google.com/extensions/detail/ljecomdaijmibecakcpjadigpfkollbh">Wet Banana</a> by Jedediah Smith
-        <br/> Inspired by <a href="http://pagesperso-orange.fr/marc.boullet/ext/extensions-en.html">Scrollbar Anywhere</a> for Firefox by Marc Boullet
+        <a href="http://github.com/davidparsson/scrollbar-anywhere/issues"
+          >Support</a
+        >
+        <br />
+        Based on
+        <a
+          href="https://chrome.google.com/extensions/detail/ljecomdaijmibecakcpjadigpfkollbh"
+          >Wet Banana</a
+        >
+        by Jedediah Smith <br />
+        Inspired by
+        <a
+          href="http://pagesperso-orange.fr/marc.boullet/ext/extensions-en.html"
+          >Scrollbar Anywhere</a
+        >
+        for Firefox by Marc Boullet
       </p>
 
-      <i>Test your settings by dragging this page</i><br/>
-      <img src="down.png" alt="Down arrow" style="margin: 0 auto;"/>
+      <i>Test your settings by dragging this page</i><br />
+      <img src="down.png" alt="Down arrow" style="margin: 0 auto" />
 
-
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
-      <div class="backtotop"><a href="#"><img src="up.png" alt="Up arrow"/><br/><br/>Back to the Top</a></div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
+      <div class="backtotop">
+        <a href="#"
+          ><img src="up.png" alt="Up arrow" /><br /><br />Back to the Top</a
+        >
+      </div>
     </div>
   </body>
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,9 +1,11 @@
-var KEYS = ["shift","ctrl","alt","meta"]
+var KEYS = ['shift', 'ctrl', 'alt', 'meta']
 
-function $(id) { return document.getElementById(id) }
+function $(id) {
+  return document.getElementById(id)
+}
 
 function error(msg) {
-  $('message').innerHTML += '<div style="color:red">'+msg+'</div>'
+  $('message').innerHTML += '<div style="color:red">' + msg + '</div>'
 }
 
 function clearMessage() {
@@ -18,32 +20,32 @@ function save() {
 
   x = $('button').selectedIndex
   if (x < 0 || x > 2) {
-    error("Somehow, you broke the button field")
+    error('Somehow, you broke the button field')
   } else o.button = x
 
-  x = $('scaling').value-0
+  x = $('scaling').value - 0
   if (isNaN(x)) {
-    error("Scaling must be a number")
+    error('Scaling must be a number')
   } else o.scaling = x / 100
 
-  x = $('speed').value-0
+  x = $('speed').value - 0
   if (isNaN(x) || x < 0) {
-    error("Top speed must be a positive number or zero")
+    error('Top speed must be a positive number or zero')
   } else o.speed = x
 
-  x = $('friction').value-0
+  x = $('friction').value - 0
   if (isNaN(x) || x < 0) {
-    error("Friction must be a positive number")
+    error('Friction must be a positive number')
   } else o.friction = x
 
   for (var i = 0; i < KEYS.length; i++) {
-    o['key_'+KEYS[i]] = $('key_'+KEYS[i]).checked
+    o['key_' + KEYS[i]] = $('key_' + KEYS[i]).checked
   }
 
   x = $('blacklist').value
   var hosts = x.split('\n')
   for (var i = hosts.length - 1; i >= 0; i--) {
-    var host = hosts[i].trim();
+    var host = hosts[i].trim()
     if (!host.match(/^[a-z0-9-.]*$/)) {
       error('The blacklisted domain name "' + host + '" is not valid')
     }
@@ -64,48 +66,55 @@ function load() {
   $('button').selectedIndex = o.button
 
   for (var i = 0; i < KEYS.length; i++) {
-    $('key_'+KEYS[i]).checked = (o['key_'+KEYS[i]]+"" == "true")
+    $('key_' + KEYS[i]).checked = o['key_' + KEYS[i]] + '' == 'true'
   }
 
-  $('scaling').value  = o.scaling * 100
-  $('speed').value    = o.speed
+  $('scaling').value = o.scaling * 100
+  $('speed').value = o.speed
   $('friction').value = o.friction
   $('blacklist').value = o.blacklist
 
-  $('cursor').checked = (o.cursor == "true")
-  $('notext').checked = (o.notext == "true")
-  $('grab_and_drag').checked = (o.grab_and_drag == "true")
-  $('debug').checked = (o.debug == "true")
+  $('cursor').checked = o.cursor == 'true'
+  $('notext').checked = o.notext == 'true'
+  $('grab_and_drag').checked = o.grab_and_drag == 'true'
+  $('debug').checked = o.debug == 'true'
 }
 
 var updateTimeoutId
 
 function onUpdate(ev) {
   if (updateTimeoutId != null) clearTimeout(updateTimeoutId)
-  updateTimeoutId = setTimeout(save,200)
+  updateTimeoutId = setTimeout(save, 200)
 
   $('windows_middle_warning').style.display =
-    ($('button').selectedIndex == 1 &&
-     navigator.userAgent.search(/Windows/) != -1 &&
-     navigator.userAgent.search(/Chrome\/[012345]\./) != -1) ? 'block' : 'none'
+    $('button').selectedIndex == 1 &&
+    navigator.userAgent.search(/Windows/) != -1 &&
+    navigator.userAgent.search(/Chrome\/[012345]\./) != -1
+      ? 'block'
+      : 'none'
 }
 
-document.addEventListener('DOMContentLoaded', function(ev) {
-  load();
-  ['button','cursor','notext','debug', 'grab_and_drag'].forEach(function(id) {
-    $(id).addEventListener('change',onUpdate,false)
-  })
+document.addEventListener(
+  'DOMContentLoaded',
+  function (ev) {
+    load()
+    ;['button', 'cursor', 'notext', 'debug', 'grab_and_drag'].forEach(
+      function (id) {
+        $(id).addEventListener('change', onUpdate, false)
+      },
+    )
 
-  KEYS.forEach(function(key) {
-    $('key_'+key).addEventListener('change',onUpdate,false)
-  })
+    KEYS.forEach(function (key) {
+      $('key_' + key).addEventListener('change', onUpdate, false)
+    })
+    ;['scaling', 'speed', 'friction', 'blacklist'].forEach(function (id) {
+      $(id).addEventListener('change', onUpdate, true)
+      $(id).addEventListener('keydown', onUpdate, true)
+      $(id).addEventListener('mousedown', onUpdate, true)
+      $(id).addEventListener('blur', onUpdate, true)
+    })
+  },
+  true,
+)
 
-  ;['scaling','speed','friction','blacklist'].forEach(function(id) {
-    $(id).addEventListener('change',onUpdate,true)
-    $(id).addEventListener('keydown',onUpdate,true)
-    $(id).addEventListener('mousedown',onUpdate,true)
-    $(id).addEventListener('blur',onUpdate,true)
-  })
-},true)
-
-document.addEventListener('unload',save,true)
+document.addEventListener('unload', save, true)

--- a/src/options.js
+++ b/src/options.js
@@ -57,12 +57,11 @@ function save() {
   o.grab_and_drag = $('grab_and_drag').checked
   o.debug = $('debug').checked
 
-  chrome.extension.getBackgroundPage().saveOptions(o)
+  console.log('Saving options:', o)
+  chrome.storage.local.set(o)
 }
 
-function load() {
-  var o = chrome.extension.getBackgroundPage().loadOptions()
-
+function load(o) {
   $('button').selectedIndex = o.button
 
   for (var i = 0; i < KEYS.length; i++) {
@@ -74,10 +73,16 @@ function load() {
   $('friction').value = o.friction
   $('blacklist').value = o.blacklist
 
-  $('cursor').checked = o.cursor == 'true'
-  $('notext').checked = o.notext == 'true'
-  $('grab_and_drag').checked = o.grab_and_drag == 'true'
-  $('debug').checked = o.debug == 'true'
+  $('cursor').checked = isTrue(o.cursor)
+  $('notext').checked = isTrue(o.notext)
+  $('grab_and_drag').checked = isTrue(o.grab_and_drag)
+  $('debug').checked = isTrue(o.debug)
+
+  console.log('Options loaded:', o)
+}
+
+function isTrue(value) {
+  return value == true || value == 'true'
 }
 
 var updateTimeoutId
@@ -97,7 +102,12 @@ function onUpdate(ev) {
 document.addEventListener(
   'DOMContentLoaded',
   function (ev) {
-    load()
+    chrome.storage.local.get(null, function (loadedOptions) {
+      console.log('Loaded stored options:', loadedOptions)
+      if (Object.keys(loadedOptions).length > 0) {
+        load(loadedOptions)
+      }
+    })
     ;['button', 'cursor', 'notext', 'debug', 'grab_and_drag'].forEach(
       function (id) {
         $(id).addEventListener('change', onUpdate, false)


### PR DESCRIPTION
Chrome requires extensions to be migrated to [Manifest V3](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3). This requires migrating from a background script to a service worker, which cannot access local storage.

- [x] Migrate to `chrome.storage.local`
  - [x] Can `content.js` and `options.js` load and store directly?
- [x] Migrate to a [Service Worker](https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers)
  - [x] Update communication with pages
    - [x] Migrate the distribution of option changes to all active tabs using another method that works with a Service Worker (if possible?), from `options.js` via `background.js` to `content.js`
    - [x] Initial loading of options in `content.js`
- [x] Migrate from `chrome.extension` to `chrome.runtime`
- [x] Migrate from `chrome.browserAction` to `chrome.action`
- [x] Migrate data from local storage [to `chrome.storage`](https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#convert-localstorage) in an offscreen document
